### PR TITLE
주식체결, 체결시간 FID번호 가져오기

### DIFF
--- a/GUI/Qthread_3.py
+++ b/GUI/Qthread_3.py
@@ -15,6 +15,12 @@ class Thread3(QThread):
   
         self.Load_code() #매수 종목/금액/수량 가져오기
 
+        self.screen_num = 5000
+        for code in self.k.portfolio_stock_dict.keys():
+            fids = self.realType.REALTYPE['주식체결']['체결시간']
+            self.k.kiwoom.dynamicCall("SetRealReg(QString, QString, QString, QString)", self.screen_num, code, fids, "1")
+            self.screen_num += 1
+
     def Lode_code(self):
         if os.path.exists("dist/Seclected_code.txt"):
             f = open("dist/Selected_code.txt","r",encoding = "utf8")


### PR DESCRIPTION
스크린 번호 설정 - 거래구분 데이터를 요청할 때마다 스크린 번호를 1씩 증가시킴
싱글턴 스크립트에 접속 후 각 종목 코드를 하나씩 빼어서 code에 입력시킴
주식체결, 체결시간 FID번호를 가져오기 위해 RealType에 접속
DB에 저장된 데이터에 대하여 실시간 "거래구분"데이터 요청